### PR TITLE
Add mitigation for CVE-2021-44228 to ES nodes

### DIFF
--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       discovery.seed_hosts: "elasticsearch2,elasticsearch3"
       cluster.initial_master_nodes: "elasticsearch1,elasticsearch2,elasticsearch3"
       bootstrap.memory_lock: "true"
-      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
     ulimits:
       memlock:
         soft: -1
@@ -54,7 +54,7 @@ services:
       discovery.seed_hosts: "elasticsearch1,elasticsearch3"
       cluster.initial_master_nodes: "elasticsearch1,elasticsearch2,elasticsearch3"
       bootstrap.memory_lock: "true"
-      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
     ulimits:
       memlock:
         soft: -1
@@ -72,7 +72,7 @@ services:
       discovery.seed_hosts: "elasticsearch1,elasticsearch2"
       cluster.initial_master_nodes: "elasticsearch1,elasticsearch2,elasticsearch3"
       bootstrap.memory_lock: "true"
-      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
     ulimits:
       memlock:
         soft: -1

--- a/enterprise/docker-compose.yml
+++ b/enterprise/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   elasticsearch:
     environment:
-      ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+      ES_JAVA_OPTS: "-Xms1g -Xmx1g -Dlog4j2.formatMsgNoLookups=true"
       bootstrap.memory_lock: "true"
       discovery.type: "single-node"
       http.host: "0.0.0.0"

--- a/open-core/docker-compose.yml
+++ b/open-core/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   elasticsearch:
     environment:
-      ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+      ES_JAVA_OPTS: "-Xms1g -Xmx1g -Dlog4j2.formatMsgNoLookups=true"
       bootstrap.memory_lock: "true"
       discovery.type: "single-node"
       http.host: "0.0.0.0"


### PR DESCRIPTION
This adds the "-Dlog4j2.formatMsgNoLookups=true" Java system property to all ES node definitions.

