### PR TITLE
Allow overriding image name through environment.

### DIFF
--- a/enterprise/docker-compose.yml
+++ b/enterprise/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     restart: "on-failure"
 
   graylog:
-    image: "graylog/graylog-enterprise:4.2"
+    image: "${GRAYLOG_IMAGE:-graylog/graylog-enterprise:4.2}"
     depends_on:
       elasticsearch:
         condition: "service_started"

--- a/enterprise/docker-compose.yml
+++ b/enterprise/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     restart: "on-failure"
 
   graylog:
-    image: "${GRAYLOG_IMAGE:-graylog/graylog-enterprise:4.2}"
+    image: "${GRAYLOG_IMAGE:-graylog/graylog-enterprise:4.3}"
     depends_on:
       elasticsearch:
         condition: "service_started"

--- a/open-core/docker-compose.yml
+++ b/open-core/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     restart: "on-failure"
 
   graylog:
-    image: "graylog/graylog:4.2"
+    image: "${GRAYLOG_IMAGE:-graylog/graylog:4.3}"
     depends_on:
       elasticsearch:
         condition: "service_started"


### PR DESCRIPTION
This small change allows overriding the Graylog image name through the `$GRAYLOG_IMAGE` environment variable, improving the ability to reuse the docker compose file.