### PR TITLE
Ulimit file added to ymls

### DIFF
--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -44,6 +44,9 @@ services:
       memlock:
         hard: -1
         soft: -1
+      nofile:
+        soft: "65536"
+        hard: "65536"
     volumes:
       - "opensearch-data-01:/usr/share/opensearch/data"
     restart: "on-failure"
@@ -65,6 +68,9 @@ services:
       memlock:
         hard: -1
         soft: -1
+      nofile:
+        soft: "65536"
+        hard: "65536"
     volumes:
       - "opensearch-data-02:/usr/share/opensearch/data"
     restart: "on-failure"
@@ -86,6 +92,9 @@ services:
       memlock:
         hard: -1
         soft: -1
+      nofile:
+        soft: "65536"
+        hard: "65536"
     volumes:
       - "opensearch-data-03:/usr/share/opensearch/data"
     restart: "on-failure"

--- a/enterprise/docker-compose.yml
+++ b/enterprise/docker-compose.yml
@@ -20,6 +20,9 @@ services:
       memlock:
         hard: -1
         soft: -1
+      nofile:
+        soft: "65536"
+        hard: "65536"
     volumes:
       - "os_data:/usr/share/opensearch/data"
     restart: "on-failure"

--- a/open-core/docker-compose.yml
+++ b/open-core/docker-compose.yml
@@ -20,6 +20,9 @@ services:
       memlock:
         hard: -1
         soft: -1
+      nofile:
+        soft: "65536"
+        hard: "65536"
     volumes:
       - "os_data:/usr/share/opensearch/data"
     restart: "on-failure"


### PR DESCRIPTION
the supplied docker-compose.yml files do not correctly configure the opensearch container out of the box.
updated all docker-compose opensearch instances with ulimit nofile soft/hard 65536. this results in graylog. this removes the error from initial deployment.

