### PR TITLE
README update: which password to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There is an environment file (`.env.example`) where you can store these environm
       cp .env.example .env
 
 
-**Important:** Be sure to to set the `GRAYLOG_PASSWORD_SECRET` and `GRAYLOG_ROOT_PASSWORD_SHA2` environment variables in the .env file! Graylog won't start without these.
+**Important:** Be sure to to set the `GRAYLOG_PASSWORD_SECRET` (needs to be atleast 16 characters long) and `GRAYLOG_ROOT_PASSWORD_SHA2` environment variables in the .env file! Graylog won't start without these.
 
 ## Starting Graylog
 
@@ -37,7 +37,7 @@ Login:
       
 Password: 
       
-      <your password from GRAYLOG_ROOT_PASSWORD_SHA2>
+      <your password from GRAYLOG_PASSWORD_SECRET>
 
 It's as simple as that!
 


### PR DESCRIPTION
## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

I am trying out the open-core version and I believe you have to use the `GRAYLOG_PASSWORD_SECRET` as the password for the web interface.

Also if your `GRAYLOG_PASSWORD_SECRET` is not 16 characters long you will get the following error:

```
open-core-mongodb-1     | {"t":{"$date":"2023-07-13T14:46:14.034+00:00"},"s":"I",  "c":"STORAGE",  "id":22430,   "ctx":"Checkpointer","msg":"WiredTiger message","attr":{"message":"[1689259574:34460][1:0xffff7b4aac80], WT_SESSION.checkpoint: [WT_VERB_CHECKPOINT_PROGRESS] saving checkpoint snapshot min: 39, snapshot max: 39 snapshot count: 0, oldest timestamp: (0, 0) , meta checkpoint timestamp: (0, 0) base write gen: 1"}}
open-core-graylog-1     | wait-for-it: waiting 15 seconds for opensearch:9200
open-core-graylog-1     | wait-for-it: opensearch:9200 is available after 0 seconds
open-core-graylog-1     | 2023-07-13 14:46:18,124 INFO : org.graylog2.featureflag.ImmutableFeatureFlagsCollector - Following feature flags are used: {default properties file=[scripting_api_preview=off, search_filter=on]}
open-core-graylog-1     | 2023-07-13 14:46:18,273 ERROR: org.graylog2.bootstrap.CmdLineTool - Invalid configuration
open-core-graylog-1     | com.github.joschi.jadconfig.ValidationException: The minimum length for "password_secret" is 16 characters.
open-core-graylog-1     | 	at org.graylog2.Configuration.validatePasswordSecret(Configuration.java:446) ~[graylog.jar:?]
open-core-graylog-1     | 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
open-core-graylog-1     | 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
open-core-graylog-1     | 	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
open-core-graylog-1     | 	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
open-core-graylog-1     | 	at com.github.joschi.jadconfig.ReflectionUtils.invokeMethodsWithAnnotation(ReflectionUtils.java:53) ~[graylog.jar:?]
open-core-graylog-1     | 	at com.github.joschi.jadconfig.JadConfig.invokeValidatorMethods(JadConfig.java:233) ~[graylog.jar:?]
open-core-graylog-1     | 	at com.github.joschi.jadconfig.JadConfig.process(JadConfig.java:102) ~[graylog.jar:?]
open-core-graylog-1     | 	at org.graylog2.bootstrap.CmdLineTool.processConfiguration(CmdLineTool.java:477) [graylog.jar:?]
open-core-graylog-1     | 	at org.graylog2.bootstrap.CmdLineTool.doRun(CmdLineTool.java:282) [graylog.jar:?]
open-core-graylog-1     | 	at org.graylog2.bootstrap.CmdLineTool.run(CmdLineTool.java:260) [graylog.jar:?]
open-core-graylog-1     | 	at org.graylog2.bootstrap.Main.main(Main.java:45) [graylog.jar:?]
open-core-graylog-1 exited with code 1
```

Note the:

```
open-core-graylog-1     | com.github.joschi.jadconfig.ValidationException: The minimum length for "password_secret" is 16 characters.
```