### PR TITLE
Update docker-compose.yml with `hostname`

### DIFF
--- a/enterprise/docker-compose.yml
+++ b/enterprise/docker-compose.yml
@@ -9,6 +9,7 @@ services:
 
   datanode:
     image: "${DATANODE_IMAGE:-graylog/graylog-datanode:5.2}"
+    hostname: "datanode"
     environment:
       GRAYLOG_DATANODE_NODE_ID_FILE: "/var/lib/graylog-datanode/node-id"
       GRAYLOG_DATANODE_PASSWORD_SECRET: "${GRAYLOG_PASSWORD_SECRET:?Please configure GRAYLOG_PASSWORD_SECRET in the .env file}"

--- a/open-core/docker-compose.yml
+++ b/open-core/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   datanode:
     image: "${DATANODE_IMAGE:-graylog/graylog-datanode:5.2}"
-    hostname: datanode
+    hostname: "datanode"
     environment:
       GRAYLOG_DATANODE_NODE_ID_FILE: "/var/lib/graylog-datanode/node-id"
       GRAYLOG_DATANODE_PASSWORD_SECRET: "${GRAYLOG_PASSWORD_SECRET:?Please configure GRAYLOG_PASSWORD_SECRET in the .env file}"

--- a/open-core/docker-compose.yml
+++ b/open-core/docker-compose.yml
@@ -9,6 +9,7 @@ services:
 
   datanode:
     image: "${DATANODE_IMAGE:-graylog/graylog-datanode:5.2}"
+    hostname: datanode
     environment:
       GRAYLOG_DATANODE_NODE_ID_FILE: "/var/lib/graylog-datanode/node-id"
       GRAYLOG_DATANODE_PASSWORD_SECRET: "${GRAYLOG_PASSWORD_SECRET:?Please configure GRAYLOG_PASSWORD_SECRET in the .env file}"


### PR DESCRIPTION
Without the `hostname` for the `datanode:` service, if that container is re-created, the unique container name that docker generates will invalidate the SSL certificate that was generated using the Graylog Preflight UI, making it practically impossible to recover from, as you can't re-trigger the Preflight UI, seemingly, as the Graylog UI on `:9000` fails to start in this situation.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

