### PR TITLE
Added docker-compose.yml for using Opensearch backend

### DIFF
--- a/enterprise/opensearch-backend/.env.example
+++ b/enterprise/opensearch-backend/.env.example
@@ -1,0 +1,44 @@
+# ====================================================== #
+# IMPORTANT!
+# Rename this file to '.env' to make your changes apply.
+# ====================================================== #
+
+# You MUST set a secret to secure/pepper the stored user passwords here. Use at least 64 characters.
+# Generate one by using for example: pwgen -N 1 -s 96
+# ATTENTION: This value must be the same on all Graylog nodes in the cluster.
+# Changing this value after installation will render all user sessions and encrypted values in the database invalid. (e.g. encrypted access tokens)
+GRAYLOG_PASSWORD_SECRET=""
+
+# You MUST specify a hash password for the root user (which you only need to initially set up the
+# system and in case you lose connectivity to your authentication backend)
+# This password cannot be changed using the API or via the web interface. If you need to change it,
+# modify it in this file.
+# Create one by using for example: echo -n yourpassword | shasum -a 256
+# and put the resulting hash value into the following line
+# CHANGE THIS!
+GRAYLOG_ROOT_PASSWORD_SHA2=""
+
+# Set desired Graylog version.
+# By default, the latest version will be used.
+# See available version tags here: https://hub.docker.com/r/graylog/graylog-enterprise/tags
+#GRAYLOG_VERSION=
+
+# Set desired Opensearch version.
+# By default, the latest version will be used.
+# See available version tags here: https://hub.docker.com/r/opensearchproject/opensearch/tags
+#OPENSEARCH_VERSION=
+
+# Set desired MongoDB version.
+# By default, the latest supported version (7.0) will be used.
+# See available version tags here: https://hub.docker.com/_/mongo/tags
+#MONGODB_VERSION=
+
+# Set desired Graylog heap (memory) size:
+#GRAYLOG_HEAP=
+
+# Set desired Opensearch heap (memory) size:
+#OPENSEARCH_HEAP=
+
+# As of v2.12, the initial Opensearch admin password must be set on first boot.
+# See docs for complexity requirements: https://opensearch.org/docs/latest/security/configuration/demo-configuration/#setting-up-a-custom-admin-password
+OPENSEARCH_INITIAL_ADMIN_PASSWORD=""

--- a/enterprise/opensearch-backend/docker-compose.yml
+++ b/enterprise/opensearch-backend/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       #- "5140:5140/tcp"   # Syslog TCP
       #- "5140:5140/udp"   # Syslog UDP
       #- "5555:5555/tcp"   # RAW TCP
-      #- "5555:5555/udp"   # RAW TCP
+      #- "5555:5555/udp"   # RAW UDP
       #- "12201:12201/tcp" # GELF TCP
       #- "12201:12201/udp" # GELF UDP
       #- "13301:13301/tcp" # Forwarder data

--- a/enterprise/opensearch-backend/docker-compose.yml
+++ b/enterprise/opensearch-backend/docker-compose.yml
@@ -1,0 +1,73 @@
+services:
+  mongodb:
+    image: "mongo:${MONGODB_VERSION:-7.0}"
+    container_name: mongodb
+    volumes:
+      - "mongodb_data:/data/db"
+    restart: "on-failure"
+
+  opensearch:
+    image: "opensearchproject/opensearch:${OPENSEARCH_VERSION:-latest}"
+    container_name: opensearch
+    environment:
+      OPENSEARCH_JAVA_OPTS: "-Xms${OPENSEARCH_HEAP:-1g} -Xmx${OPENSEARCH_HEAP:-1g}"
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: "${OPENSEARCH_INITIAL_ADMIN_PASSWORD:?Please configure the OPENSEARCH_INITIAL_ADMIN_PASSWORD in the .env file}"
+      bootstrap.memory_lock: "true"
+      discovery.type: "single-node"
+      action.auto_create_index: "false"
+      plugins.security.ssl.http.enabled: "false"
+      plugins.security.disabled: "true"
+      DISABLE_INSTALL_DEMO_CONFIG: "true" # disables execution of install_demo_configuration.sh bundled with security plugin, which installs demo certificates and security configurations to OpenSearch
+    ulimits:
+      memlock:
+        hard: -1
+        soft: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - "opensearch_data:/usr/share/opensearch/data"
+    restart: "on-failure"
+
+  graylog:
+    image: "graylog/graylog-enterprise:${GRAYLOG_VERSION:-6.0}"
+    container_name: graylog
+    depends_on:
+      opensearch:
+        condition: "service_started"
+      mongodb:
+        condition: "service_started"
+    entrypoint: "/usr/bin/tini -- wait-for-it opensearch:9200 --  /docker-entrypoint.sh"
+    environment:
+      GRAYLOG_NODE_ID_FILE: "/usr/share/graylog/data/config/node-id"
+      GRAYLOG_PASSWORD_SECRET: "${GRAYLOG_PASSWORD_SECRET:?Please configure GRAYLOG_PASSWORD_SECRET in the .env file}"
+      GRAYLOG_ROOT_PASSWORD_SHA2: "${GRAYLOG_ROOT_PASSWORD_SHA2:?Please configure GRAYLOG_ROOT_PASSWORD_SHA2 in the .env file}"
+      GRAYLOG_HTTP_BIND_ADDRESS: "0.0.0.0:9000"
+      GRAYLOG_HTTP_EXTERNAL_URI: "http://localhost:9000/"
+      GRAYLOG_ELASTICSEARCH_HOSTS: "http://opensearch:9200"
+      GRAYLOG_MONGODB_URI: "mongodb://mongodb:27017/graylog"
+      # To make reporting (headless_shell) work inside a Docker container
+      GRAYLOG_REPORT_DISABLE_SANDBOX: "true"
+      GRAYLOG_SERVER_JAVA_OPTS: "-Xms${GRAYLOG_HEAP:-1g} -Xmx${GRAYLOG_HEAP:-1g}"
+    ports:
+      - "9000:9000/tcp"   # Server API
+      # Enable the rest as needed for inputs:
+      #- "5044:5044/tcp"   # Beats
+      #- "5140:5140/tcp"   # Syslog TCP
+      #- "5140:5140/udp"   # Syslog UDP
+      #- "5555:5555/tcp"   # RAW TCP
+      #- "5555:5555/udp"   # RAW TCP
+      #- "12201:12201/tcp" # GELF TCP
+      #- "12201:12201/udp" # GELF UDP
+      #- "13301:13301/tcp" # Forwarder data
+      #- "13302:13302/tcp" # Forwarder config
+    volumes:
+      - "graylog_data:/usr/share/graylog/data/data"
+      - "graylog_journal:/usr/share/graylog/data/journal"
+    restart: "on-failure"
+
+volumes:
+  mongodb_data:
+  opensearch_data:
+  graylog_data:
+  graylog_journal:


### PR DESCRIPTION
Even though we've released Data Node, using Opensearch as an indexing backend is still supported, so still deserves to have a deployment configuration reference

## Notes for Reviewers

- [x] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [x] Sync up with the author before merging

