### PR TITLE
Environment variable GRAYLOG_IS_MASTER is deprecated

### DIFF
--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -174,7 +174,7 @@ services:
       - "mongodb3"
     entrypoint: "/docker-entrypoint.sh"
     environment:
-      GRAYLOG_IS_MASTER: "false"
+      GRAYLOG_IS_LEADER: "false"
       GRAYLOG_NODE_ID_FILE: "/usr/share/graylog/data/data/node-id"
       GRAYLOG_PASSWORD_SECRET: "${GRAYLOG_PASSWORD_SECRET:?Please configure GRAYLOG_PASSWORD_SECRET in the .env file}"
       GRAYLOG_ROOT_PASSWORD_SHA2: "${GRAYLOG_ROOT_PASSWORD_SHA2:?Please configure GRAYLOG_ROOT_PASSWORD_SHA2 in the .env file}"
@@ -204,7 +204,7 @@ services:
       - "mongodb3"
     entrypoint: "/docker-entrypoint.sh"
     environment:
-      GRAYLOG_IS_MASTER: "false"
+      GRAYLOG_IS_LEADER: "false"
       GRAYLOG_NODE_ID_FILE: "/usr/share/graylog/data/data/node-id"
       GRAYLOG_PASSWORD_SECRET: "${GRAYLOG_PASSWORD_SECRET:?Please configure GRAYLOG_PASSWORD_SECRET in the .env file}"
       GRAYLOG_ROOT_PASSWORD_SHA2: "${GRAYLOG_ROOT_PASSWORD_SHA2:?Please configure GRAYLOG_ROOT_PASSWORD_SHA2 in the .env file}"


### PR DESCRIPTION
The configuration setting is_master got changed to is_leader, therefore the environment variable has to be changed to GRAYLOG_IS_LEADER

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

