### PR TITLE
Fix preflight issue reaching from VM

### DIFF
--- a/enterprise/docker-compose.yml
+++ b/enterprise/docker-compose.yml
@@ -35,9 +35,9 @@ services:
         soft: 65536
         hard: 65536
     ports:
-      - "127.0.0.1:8999:8999/tcp"   # DataNode API
-      - "127.0.0.1:9200:9200/tcp"
-      - "127.0.0.1:9300:9300/tcp"
+      - "8999:8999/tcp"   # DataNode API
+      - "9200:9200/tcp"
+      - "9300:9300/tcp"
     networks:
       - graylog 
     volumes:
@@ -64,18 +64,18 @@ services:
       # To make reporting (headless_shell) work inside a Docker container
       GRAYLOG_REPORT_DISABLE_SANDBOX: "true"
     ports:
-    - "127.0.0.1:5044:5044/tcp"   # Beats
-    - "127.0.0.1:5140:5140/tcp"   # Syslog TCP
-    - "127.0.0.1:5140:5140/udp"   # Syslog UDP
-    - "127.0.0.1:5555:5555/tcp"   # RAW TCP
-    - "127.0.0.1:5555:5555/udp"   # RAW UDP
-    - "127.0.0.1:9000:9000/tcp"   # Server API
-    - "127.0.0.1:12201:12201/tcp" # GELF TCP
-    - "127.0.0.1:12201:12201/udp" # GELF UDP
-    #- "127.0.0.1:10000:10000/tcp" # Custom TCP port
-    #- "127.0.0.1:10000:10000/udp" # Custom UDP port
-    - "127.0.0.1:13301:13301/tcp" # Forwarder data
-    - "127.0.0.1:13302:13302/tcp" # Forwarder config
+    - "5044:5044/tcp"   # Beats
+    - "5140:5140/tcp"   # Syslog TCP
+    - "5140:5140/udp"   # Syslog UDP
+    - "5555:5555/tcp"   # RAW TCP
+    - "5555:5555/udp"   # RAW UDP
+    - "9000:9000/tcp"   # Server API
+    - "12201:12201/tcp" # GELF TCP
+    - "12201:12201/udp" # GELF UDP
+    #- "10000:10000/tcp" # Custom TCP port
+    #- "10000:10000/udp" # Custom UDP port
+    - "13301:13301/tcp" # Forwarder data
+    - "13302:13302/tcp" # Forwarder config
     networks:
       - graylog 
     volumes:

--- a/forwarder/docker-compose.yml
+++ b/forwarder/docker-compose.yml
@@ -9,15 +9,15 @@ services:
       # running version <=5.1-1 of the Forwarder image.
       #GRAYLOG_NODE_ID_FILE: "/var/lib/graylog-forwarder/node-id"
     ports:
-      - "127.0.0.1:5044:5044/tcp"   # Beats
-      - "127.0.0.1:5140:5140/udp"   # Syslog
-      - "127.0.0.1:5140:5140/tcp"   # Syslog
-      - "127.0.0.1:5555:5555/tcp"   # RAW TCP
-      - "127.0.0.1:5555:5555/udp"   # RAW UDP
-      - "127.0.0.1:12201:12201/tcp" # GELF TCP
-      - "127.0.0.1:12201:12201/udp" # GELF UDP
-      #- "127.0.0.1:10000:10000/tcp" # Custom TCP port
-      #- "127.0.0.1:10000:10000/udp" # Custom UDP port
+      - "5044:5044/tcp"   # Beats
+      - "5140:5140/udp"   # Syslog
+      - "5140:5140/tcp"   # Syslog
+      - "5555:5555/tcp"   # RAW TCP
+      - "5555:5555/udp"   # RAW UDP
+      - "12201:12201/tcp" # GELF TCP
+      - "12201:12201/udp" # GELF UDP
+      #- "10000:10000/tcp" # Custom TCP port
+      #- "10000:10000/udp" # Custom UDP port
     volumes:
       - "forwarder-data:/var/lib/graylog-forwarder"
       #- "/path/to/custom/jvm.options:/etc/graylog/forwarder/jvm.options"

--- a/open-core/docker-compose.yml
+++ b/open-core/docker-compose.yml
@@ -35,9 +35,9 @@ services:
         soft: 65536
         hard: 65536
     ports:
-      - "127.0.0.1:8999:8999/tcp"   # DataNode API
-      - "127.0.0.1:9200:9200/tcp"
-      - "127.0.0.1:9300:9300/tcp"
+      - "8999:8999/tcp"   # DataNode API
+      - "9200:9200/tcp"
+      - "9300:9300/tcp"
     networks:
       - graylog  
     volumes:
@@ -63,18 +63,18 @@ services:
       GRAYLOG_HTTP_EXTERNAL_URI: "http://localhost:9000/"
       GRAYLOG_MONGODB_URI: "mongodb://mongodb:27017/graylog"
     ports:
-    - "127.0.0.1:5044:5044/tcp"   # Beats
-    - "127.0.0.1:5140:5140/udp"   # Syslog
-    - "127.0.0.1:5140:5140/tcp"   # Syslog
-    - "127.0.0.1:5555:5555/tcp"   # RAW TCP
-    - "127.0.0.1:5555:5555/udp"   # RAW UDP
-    - "127.0.0.1:9000:9000/tcp"   # Server API
-    - "127.0.0.1:12201:12201/tcp" # GELF TCP
-    - "127.0.0.1:12201:12201/udp" # GELF UDP
-    #- "127.0.0.1:10000:10000/tcp" # Custom TCP port
-    #- "127.0.0.1:10000:10000/udp" # Custom UDP port
-    - "127.0.0.1:13301:13301/tcp" # Forwarder data
-    - "127.0.0.1:13302:13302/tcp" # Forwarder config
+    - "5044:5044/tcp"   # Beats
+    - "5140:5140/udp"   # Syslog
+    - "5140:5140/tcp"   # Syslog
+    - "5555:5555/tcp"   # RAW TCP
+    - "5555:5555/udp"   # RAW UDP
+    - "9000:9000/tcp"   # Server API
+    - "12201:12201/tcp" # GELF TCP
+    - "12201:12201/udp" # GELF UDP
+    #- "10000:10000/tcp" # Custom TCP port
+    #- "10000:10000/udp" # Custom UDP port
+    - "13301:13301/tcp" # Forwarder data
+    - "13302:13302/tcp" # Forwarder config
     networks:
       - graylog
     volumes:


### PR DESCRIPTION
Fix for https://community.graylog.org/t/cant-connect-to-preflight-using-graylog-7-docker-compose-file/36838

"127.0.0.1:9000:9000/tcp"
That means port 9000 is only reachable on the VM itself (loopback), not via http://192.168.69.240:9000/

Deleting 127.0.0.1 allows to listen now all interfaces
