### PR TITLE
Fix docker-compose network format

### DIFF
--- a/enterprise/docker-compose.yml
+++ b/enterprise/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - "127.0.0.1:9200:9200/tcp"
       - "127.0.0.1:9300:9300/tcp"
     networks:
-      - graylog 
+      - graylog
     volumes:
       - "graylog-datanode:/var/lib/graylog-datanode"
     restart: "on-failure"

--- a/open-core/docker-compose.yml
+++ b/open-core/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - "127.0.0.1:9200:9200/tcp"
       - "127.0.0.1:9300:9300/tcp"
     networks:
-      - graylog  
+      - graylog
     volumes:
       - "graylog-datanode:/var/lib/graylog-datanode"
     restart: "on-failure"


### PR DESCRIPTION
## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

The two spaces in the network config causes the graylog datanode to not be able to join the graylog network.

Valid Network Name:
```yml
services:  
  datanode:
    image: "${DATANODE_IMAGE:-graylog/graylog-datanode:7.1}"
    hostname: "datanode"
    networks:
      - graylog
```

Invalid Network Name:
```yml
services:  
  datanode:
    image: "${DATANODE_IMAGE:-graylog/graylog-datanode:7.1}"
    hostname: "datanode"
    networks:
      - graylog  
```

```
datanode-1  | 2026-06-16T13:05:12.698Z INFO  [cluster] Exception in monitor thread while connecting to server mongodb:27017
datanode-1  | com.mongodb.MongoSocketException: mongodb: Temporary failure in name resolution
datanode-1  | 	at com.mongodb.internal.connection.ServerAddressHelper.getSocketAddresses(ServerAddressHelper.java:75)
datanode-1  | 	at com.mongodb.internal.connection.SocketStream.initializeSocket(SocketStream.java:100)
datanode-1  | 	at com.mongodb.internal.connection.SocketStream.open(SocketStream.java:79)
datanode-1  | 	at com.mongodb.internal.connection.InternalStreamConnection.open(InternalStreamConnection.java:233)
datanode-1  | 	at com.mongodb.internal.connection.DefaultServerMonitor$ServerMonitor.setupNewConnectionAndGetInitialDescription(DefaultServerMonitor.java:282)
datanode-1  | 	at com.mongodb.internal.connection.DefaultServerMonitor$ServerMonitor.lookupServerDescription(DefaultServerMonitor.java:253)
datanode-1  | 	at com.mongodb.internal.connection.DefaultServerMonitor$ServerMonitor.run(DefaultServerMonitor.java:203)
datanode-1  | Caused by: java.net.UnknownHostException: mongodb: Temporary failure in name resolution
datanode-1  | 	at java.base/java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method)
datanode-1  | 	at java.base/java.net.Inet6AddressImpl.lookupAllHostAddr(Unknown Source)
datanode-1  | 	at java.base/java.net.InetAddress$PlatformResolver.lookupByName(Unknown Source)
datanode-1  | 	at java.base/java.net.InetAddress.getAddressesFromNameService(Unknown Source)
datanode-1  | 	at java.base/java.net.InetAddress$NameServiceAddresses.get(Unknown Source)
datanode-1  | 	at java.base/java.net.InetAddress.getAllByName0(Unknown Source)
datanode-1  | 	at java.base/java.net.InetAddress.getAllByName(Unknown Source)
datanode-1  | 	at com.mongodb.internal.connection.DefaultInetAddressResolver.lookupByName(DefaultInetAddressResolver.java:34)
datanode-1  | 	at com.mongodb.internal.connection.ServerAddressHelper.getSocketAddresses(ServerAddressHelper.java:71)
datanode-1  | 	... 6 more
```

**BEFORE:**
`docker network inspect graylog_graylog`

```json
[
    {
        "Name": "graylog_graylog",
        "Id": "956634ff6bbcf85d85b558cd52f810cdcc37005219cb4b844e23c93403d42889",
        "Created": "2026-06-16T12:48:09.750387708Z",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv4": true,
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": null,
            "Config": [
                {
                    "Subnet": "172.20.0.0/16",
                    "Gateway": "172.20.0.1"
                }
            ]
        },
        "Internal": false,
        "Attachable": false,
        "Ingress": false,
        "ConfigFrom": {
            "Network": ""
        },
        "ConfigOnly": false,
        "Options": {},
        "Labels": {
            "com.docker.compose.config-hash": "91668464032bab2dc582df288393417259577e0a2ade8f4691a9ce1f88715044",
            "com.docker.compose.network": "graylog",
            "com.docker.compose.project": "graylog",
            "com.docker.compose.version": "5.0.2"
        },
        "Containers": {
            "03e06a00770de7e056c765f6127628940e6cb2f0cf12294163c51609bb34ba3b": {
                "Name": "graylog-graylog-1",
                "EndpointID": "de2ef56ae713d5a027723dd0f007f5ac15834993f7e4441948215bc3cfed03ce",
                "MacAddress": "8e:3a:83:a0:45:19",
                "IPv4Address": "172.20.0.3/16",
                "IPv6Address": ""
            },
            "a14f8f943fb70a81e76367762d274d60414862f3018cd3998b6363bd4b66d76d": {
                "Name": "graylog-mongodb-1",
                "EndpointID": "ba1d49a3fea1b1838069fa05a4d6e048de93aaf4c0b1a81ab62ee09e200b58ce",
                "MacAddress": "5e:6b:47:28:e1:94",
                "IPv4Address": "172.20.0.2/16",
                "IPv6Address": ""
            }
        },
        "Status": {
            "IPAM": {
                "Subnets": {
                    "172.20.0.0/16": {
                        "IPsInUse": 5,
                        "DynamicIPsAvailable": 65531
                    }
                }
            }
        }
    }
]
```

**AFTER:**
`docker network inspect graylog_graylog`

```json
[
    {
        "Name": "graylog_graylog",
        "Id": "1587270cd97952fc5c3d111e2dadf94845cc950969cdc2d01d58b8d9f25892ab",
        "Created": "2026-06-16T13:26:06.172393179Z",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv4": true,
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": null,
            "Config": [
                {
                    "Subnet": "172.18.0.0/16",
                    "Gateway": "172.18.0.1"
                }
            ]
        },
        "Internal": false,
        "Attachable": false,
        "Ingress": false,
        "ConfigFrom": {
            "Network": ""
        },
        "ConfigOnly": false,
        "Options": {},
        "Labels": {
            "com.docker.compose.config-hash": "91668464032bab2dc582df288393417259577e0a2ade8f4691a9ce1f88715044",
            "com.docker.compose.network": "graylog",
            "com.docker.compose.project": "graylog",
            "com.docker.compose.version": "5.0.2"
        },
        "Containers": {
            "49b1fbdd9af894e7c0d61e9c7f265d602925b44d5886d8396dc579306a0b9aaf": {
                "Name": "graylog-mongodb-1",
                "EndpointID": "2ab4e8793169e0a79e6cb16cbce893e9f20f22138c92e1de00c0d3f89b68adba",
                "MacAddress": "d2:86:df:80:9c:21",
                "IPv4Address": "172.18.0.2/16",
                "IPv6Address": ""
            },
            "c32ea0cc97925c5e148ea874dd58089de8477d7d518397ccd137bb41db2f8a8a": {
                "Name": "graylog-datanode-1",
                "EndpointID": "2dabb245e725df1129b056dd2514641b3b384c120292c65ab73965b3d9729351",
                "MacAddress": "92:e5:1e:6b:29:e3",
                "IPv4Address": "172.18.0.3/16",
                "IPv6Address": ""
            },
            "d19e499ee1285b7ea9a2acdeea09c201bf790189978df98a1e7747b27650d682": {
                "Name": "graylog-graylog-1",
                "EndpointID": "c2e1bc6d9fe61a40af47ac30d4b1240396b582eaff171e77277c187c27cc1f77",
                "MacAddress": "0e:a2:05:9d:29:95",
                "IPv4Address": "172.18.0.4/16",
                "IPv6Address": ""
            }
        },
        "Status": {
            "IPAM": {
                "Subnets": {
                    "172.18.0.0/16": {
                        "IPsInUse": 6,
                        "DynamicIPsAvailable": 65530
                    }
                }
            }
        }
    }
]
```